### PR TITLE
Removed default value of Instance types to be used by spotinst

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -176,7 +176,6 @@ variable "spotinst_region" {
 
 variable "spotinst_whitelist" {
   description = "Instance types to be used by spotinst (default: c3, c4, c5, m3, m4, m5 family)"
-  default     = "c3.large,c3.xlarge,c3.2xlarge,c3.4xlarge,c3.8xlarge,c4.large,c4.xlarge,c4.2xlarge,c4.4xlarge,c4.8xlarge,c5.large,c5.xlarge,c5.2xlarge,c5.4xlarge,c5.9xlarge,c5.18xlarge,m3.medium,m3.large,m3.xlarge,m3.2xlarge,m4.large,m4.xlarge,m4.2xlarge,m4.4xlarge,m4.10xlarge,m4.16xlarge,m5.12xlarge,m5.24xlarge,m5.2xlarge,m5.4xlarge,m5.large,m5.xlarge,m5.8xlarge"
 }
 
 variable "spotinst_max_size" {


### PR DESCRIPTION
https://moneysmart.atlassian.net/browse/CLOUDOPS-90
Remove c3-8xlarge from product-listing cluster config